### PR TITLE
add primary hostname placeholder

### DIFF
--- a/install/debian/12/exim/exim4.conf.template
+++ b/install/debian/12/exim/exim4.conf.template
@@ -4,7 +4,6 @@
 #                                                                    #
 ######################################################################
 
-
 # Placeholder for primary_hostname (to be set dynamically during installation)
 # primary_hostname = mail.domain.com
 


### PR DESCRIPTION
Adding a primary_hostname placeholder in exim4.conf.template, set to mail.<base domain> via vst-install-debian.sh and v-rebuild-exim4-config.

Updating acl_check_rcpt to allow unauthenticated local domain deliveries on port 25, while blocking non-local sends to prevent relaying.